### PR TITLE
Load JS without publishing

### DIFF
--- a/src/MarkdownFieldServiceProvider.php
+++ b/src/MarkdownFieldServiceProvider.php
@@ -20,7 +20,7 @@ class MarkdownFieldServiceProvider extends PackageServiceProvider
     public function bootingPackage()
     {
         Filament::registerScripts([
-            url('vendor/filament-markdown-field/editor.js'),
+            'markdown-field' => __DIR__ . '/../resources/dist/editor.js',
         ], true);
 
         Filament::registerStyles([


### PR DESCRIPTION
If you define an internal path to the JS file, Filament will recognise that and serve it through an asset controller :) So users don't need to publish any JS to make the package work