### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,8 +22,10 @@ jobs:
         include:
           - laravel: 12.*
             testbench: 10.*
+            filament: ^3.0
           - laravel: 13.*
             testbench: 11.*
+            filament: ^5.2
         exclude:
           - laravel: 13.*
             php: 8.2
@@ -48,7 +50,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:${{ matrix.filament }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,13 +17,18 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: ['11.*', '12.*']
+        laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,11 +17,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: ['11.*', '12.*', '13.*']
+        laravel: ['12.*', '13.*']
         stability: [prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*
@@ -50,7 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:^3.0" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "filament/filament": "^3.0|^5.2",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.13.6"
     },
     "require-dev": {
         "laravel/pint": "^1.2",
-        "nunomaduro/collision": "^6.3.1|^8.0",
-        "orchestra/testbench": "^7.10.1|^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^1.22.1|^2.34|^3.7|^4.4",
-        "pestphp/pest-plugin-laravel": "^1.3|^2.3|^3.1|^4.1",
-        "phpunit/phpunit": "^9.5.25|^10.5|^11.5.3|^12.5.12"
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^3.7|^4.4",
+        "pestphp/pest-plugin-laravel": "^3.1|^4.1",
+        "phpunit/phpunit": "^11.5.3|^12.5.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,17 +27,17 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^3.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "filament/filament": "^3.0|^5.2",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.13.6"
     },
     "require-dev": {
         "laravel/pint": "^1.2",
         "nunomaduro/collision": "^6.3.1|^8.0",
-        "orchestra/testbench": "^7.10.1|^8.0|^9.0|^10.0",
-        "pestphp/pest": "^1.22.1|^2.34|^3.7",
-        "pestphp/pest-plugin-laravel": "^1.3|^2.3|^3.1",
-        "phpunit/phpunit": "^9.5.25|^10.5|^11.5.3"
+        "orchestra/testbench": "^7.10.1|^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^1.22.1|^2.34|^3.7|^4.4",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.3|^3.1|^4.1",
+        "phpunit/phpunit": "^9.5.25|^10.5|^11.5.3|^12.5.12"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,12 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,24 +12,15 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
 >
     <testsuites>
         <testsuite name="Spatie Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary
- Add Laravel 13 and Filament 5.2 support
- Drop Laravel 9, 10, 11 support (L12 and L13 only)
- Migrate phpunit.xml.dist to PHPUnit 12 compatible schema
- Bump minimum PHP to 8.2

Based on #43 by Laravel Shift.